### PR TITLE
Add 'ignore-ssl-errors' flag.

### DIFF
--- a/bin/analyze-css.js
+++ b/bin/analyze-css.js
@@ -22,7 +22,7 @@ program
 	.describe('url', 'Set URL of CSS to analyze').string('url')
 	.describe('file', 'Set local CSS file to analyze').string('file')
 
-	.describe('ignore-ssl-errors', 'ignores SSL errors, such as expired or self-signed certificate errors').boolean('ignore-ssl-errors')
+	.describe('ignore-ssl-errors', 'Ignores SSL errors, such as expired or self-signed certificate errors').boolean('ignore-ssl-errors')
 	.describe('pretty', 'Causes JSON with the results to be pretty-printed').boolean('pretty').alias('pretty', 'p')
 
 	// version / help

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -20,7 +20,7 @@ var cli = require('cli'),
  */
 function request(requestOptions, callback) {
 	var debug = require('debug')('analyze-css:http'),
-		isHttps = requestOptions.protocol == 'https:',
+		isHttps = requestOptions.protocol === 'https:',
 		client = require(isHttps ? 'https' : 'http');
 
 	debug('GET %s', requestOptions.href);


### PR DESCRIPTION
Hi — love `analyze-css` and really want to be able to use it with phantomas. :)

I struck a hurdle though as the server I want to run tests against has in invalid self-signed SSL cert.

Currently analyze-css will explode with `Error: HTTP request failed: Error: SELF_SIGNED_CERT_IN_CHAIN` trying to fetch content from this server.

This PR adds an `--ignore-ssl-errors` bool flag that will allow for getting content from servers that have busted SSL certs. It makes a few changes to option passing in the main executable, and changes the `request` method in the runner to take an object instead of just a URL as a string.
### Phantomas integration

I would love to add a follow-on PR for phantomas that will pass down along the `--ignore-ssl-errors` option from phantomas into analyze-css, however I’m not sure if this is the right thing to do (seems to make most sense?), and also not sure how you want to handle the version locking between the two (assuming this PR is accepted and a release made).

Cheers! :)
