### PR TITLE
Upgrade to autoprefixer-core v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "specificity": "~0.1.3"
   },
   "devDependencies": {
-    "autoprefixer-core": "~3.1.2",
+    "autoprefixer-core": "~4.0.0",
     "glob": "~4.0.5",
     "istanbul": "~0.3.0",
     "jshint": "~2.5.2",

--- a/rules/prefixes.json
+++ b/rules/prefixes.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2014-11-06 using autoprefixer-core v3.1.2",
+  "generated": "2014-11-18 using autoprefixer-core v4.0.0",
   "browsers": [
     "ie 11",
     "ie 10",
@@ -1289,6 +1289,22 @@
       "msg": "required by chrome 36, safari 7.1, ios_saf 7.1, android 4.1 and later"
     },
     "-o-mask-size": {
+      "keep": true,
+      "msg": "required by opera 24 and later"
+    },
+    "-ms-box-decoration-break": {
+      "keep": false,
+      "msg": "prefix is no longer supported"
+    },
+    "-moz-box-decoration-break": {
+      "keep": false,
+      "msg": "prefix is no longer supported"
+    },
+    "-webkit-box-decoration-break": {
+      "keep": true,
+      "msg": "required by chrome 36, safari 7.1, ios_saf 7.1, android 4.1 and later"
+    },
+    "-o-box-decoration-break": {
       "keep": true,
       "msg": "required by opera 24 and later"
     }


### PR DESCRIPTION
Only `-webkit-box-decoration-break` is required
