### PR TITLE
Update node-sass dependency version to v3.0.0-alpha

### DIFF
--- a/lib/preprocessors/sass.js
+++ b/lib/preprocessors/sass.js
@@ -46,6 +46,6 @@ module.exports = {
 			});
 		}
 
-		return out;
+		return out.css.toString();
 	}
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "~2.1.0",
     "fast-stats": "0.0.x",
     "glob": "4.4.x",
-    "node-sass": "1.1.2",
+    "node-sass": "3.0.0-alpha.0",
     "onecolor": "2.4.x",
     "optimist": "0.6.x",
     "slick": "~1.12.1",


### PR DESCRIPTION
Resolves #89

Use [v3.0.0 alpha](https://github.com/sass/node-sass/releases/tag/v3.0.0-alpha.1)