### PR TITLE
added position dump for unparsed selectors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -227,7 +227,8 @@ analyzer.prototype = {
 						parsedSelector = slickParse(selector)[0];
 
 						if (typeof parsedSelector === 'undefined') {
-							throw 'Unable to parse "' + selector + '" selector';
+							var positionDump = "Rule position start: " + rule.position.start.line + ',' + rule.position.start.column + "; end: " + rule.position.end.line + ',' + rule.position.end.column;
+							throw 'Unable to parse "' + selector + '" selector. ' + positionDump;
 						}
 
 						// convert object with keys to array with numeric index


### PR DESCRIPTION
Otherwise it is really hard to find empty selectors, like the following (note the last comma):
input.input-text, select, textarea, button, {}