### PR TITLE
Basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ echo ".foo {margin: 0 \!important}" | analyze-css -
 
 This will emit JSON formatted results on ``stdout``. Use ``--pretty`` (or ``-p`` shortcut) option to make the output readable for human beings.
 
+Basic HTTP authentication can be provided through the options `--auth-user` and `--auth-pass`.
+
 ### CommonJS module
 
 ```js

--- a/bin/analyze-css.js
+++ b/bin/analyze-css.js
@@ -24,6 +24,8 @@ program
 	.describe('ignore-ssl-errors', 'Ignores SSL errors, such as expired or self-signed certificate errors').boolean('ignore-ssl-errors')
 	.describe('pretty', 'Causes JSON with the results to be pretty-printed').boolean('pretty').alias('pretty', 'p')
 	.describe('no-offenders', 'Show only the metrics without the offenders part').boolean('no-offenders').alias('no-offenders', 'N')
+	.describe('auth-user', 'Sets the user name used for HTTP authentication').string('auth-user')
+	.describe('auth-pass', 'Sets the password used for HTTP authentication').string('auth-pass')
 	// version / help
 	.describe('version', 'Show version number and quit').boolean('version').alias('version', 'V')
 	.describe('help', 'This help text').boolean('help').alias('help', 'h');
@@ -66,6 +68,8 @@ else {
 
 runnerOpts.ignoreSslErrors = argv['ignore-ssl-errors'];
 runnerOpts.noOffenders = argv['no-offenders'] || (argv.offenders === false);
+runnerOpts.authUser = argv['auth-user'];
+runnerOpts.authPass = argv['auth-pass'];
 
 debug('opts: %j', runnerOpts);
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -84,6 +84,10 @@ function runner(options, callback) {
 			'User-Agent': getUserAgent()
 		};
 
+		if (options.authUser && options.authPass) {
+			requestOptions.auth = options.authUser + ':' + options.authPass;
+		}
+
 		request(requestOptions, function(err, resp, css) {
 			if (err || resp.statusCode !== 200) {
 				err = new Error('HTTP request failed: ' + (err ? err.toString() : 'received HTTP ' + resp.statusCode));


### PR DESCRIPTION
Adding basic http authentication to analyze-css. This is the first step to https://github.com/macbre/phantomas/issues/500#issuecomment-98699892

An idea on how to proxify a request with 'http' and 'https' modules?

Didn't write tests because it's kind of hard to simulate...