### PR TITLE
Fix parsing of gzipped distant files

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -129,7 +129,8 @@ function runner(options, callback) {
 		var requestOptions = url.parse(options.url);
 		requestOptions.rejectUnauthorized = !options.ignoreSslErrors;
 		requestOptions.headers = {
-			'User-Agent': getUserAgent()
+			'User-Agent': getUserAgent(),
+			'Accept-Encoding': 'gzip, deflate'
 		};
 
 		if (options.authUser && options.authPass) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -11,7 +11,8 @@ var cli = require('cli'),
 	resolve = require('path').resolve,
 	analyzer = require('./index'),
 	preprocessors = new(require('./preprocessors'))(),
-	url = require('url');
+	url = require('url'),
+	zlib = require('zlib');
 
 /**
  * Return user agent to be used by analyze-css when making HTTP requests (issue #75)
@@ -46,15 +47,62 @@ function request(requestOptions, callback) {
 	client.get(requestOptions, function(resp) {
 		var out = '';
 
-		resp.on('data', function(chunk) {
-			out += chunk;
-		});
+		switch (resp.headers['content-encoding']) {
+			case 'gzip': 
+				var gzip = zlib.createGunzip();
 
-		resp.on('end', function() {
-			debug('HTTP %d', resp.statusCode);
-			debug('Headers: %j', resp.headers);
-			callback(null, resp, out);
-		});
+                gzip.on('data', function (chunk) {
+                    out += chunk;
+                });
+
+                gzip.on('end', function() {
+                	debug('HTTP %d', resp.statusCode);
+					debug('Headers: %j', resp.headers);
+					callback(null, resp, out);
+                });
+
+                gzip.on('error', function(err) {
+                    err = new Error('Error while decoding ' + requestOptions.href + ': ' + err.toString());
+                    callback(err);
+                });
+
+                resp.pipe(gzip);
+
+				break;
+			case 'deflate':
+				var deflate = zlib.createInflate();
+
+                deflate.on('data', function (chunk) {
+                    out += chunk;
+                });
+
+                deflate.on('end', function() {
+                	debug('HTTP %d', resp.statusCode);
+					debug('Headers: %j', resp.headers);
+					callback(null, resp, out);
+                });
+
+                gzip.on('error', function(err) {
+                    err = new Error('Error while decoding ' + requestOptions.href + ': ' + err.toString());
+                    callback(err);
+                });
+
+                resp.pipe(deflate);
+
+				break;
+			default:
+				resp.on('data', function(chunk) {
+					out += chunk;
+				});
+
+				resp.on('end', function() {
+					debug('HTTP %d', resp.statusCode);
+					debug('Headers: %j', resp.headers);
+					callback(null, resp, out);
+				});
+
+				break;
+		}
 	}).on('error', function(err) {
 		debug(err);
 		callback(err);


### PR DESCRIPTION
Hi!

Analyze-css fails to parse some files when they are compressed.

Some servers are misconfigured, they always return compressed content, even if the request doesn't contain the `Accept-Encoding` header. This leads to problems with analyze-css, which is not able to ungzip these files.

Example:
```
$ analyze-css --url=http://cdn.quilt.janrain.com/2.2.19/providers.css

"offenders": {
    "parsingErrors": [
      "missing '}' @ 1:120",
      "property missing ':' @ 1:125",
      "missing '}' @ 1:125",
      "property missing ':' @ 1:306",
      "missing '}' @ 1:306",
      "property missing ':' @ 2:226",
      "missing '}' @ 2:226",
      "missing '}' @ 2:305",
      "missing '}' @ 2:577",
      "missing '}' @ 3:24",
      "selector missing @ 3:24"
    ]
  }
```

While downloading the file and running a local test using `--file` instead of `--url` works without any parsing errors.


The fix adds compatibility with gzip and deflate to analyze-css.

I have also taken the liberty to add an `Accept-Encoding:gzip, deflate` header to the requests, to save a little bandwidth and speed-up analyze-css.