### PR TITLE
Wait for stdout flush (fixes #130)

### DIFF
--- a/bin/analyze-css.js
+++ b/bin/analyze-css.js
@@ -105,8 +105,5 @@ runner(runnerOpts, function(err, res) {
 		output = JSON.stringify(res);
 	}
 
-	console.log(output);
-
-	// done
-	process.exit(0);
+	process.stdout.write(output);
 });


### PR DESCRIPTION
Do not call `process.exit` directly after a call to `console.log` as it may require some time to flush the output for large results.

See https://github.com/macbre/phantomas/issues/596 for a similar issue.