### PR TITLE
CommonJS: expose the full path to module and "bin" script

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@
 var cssParser = require('css').parse,
 	debug = require('debug')('analyze-css'),
 	fs = require('fs'),
+	path = require('path'),
 	preprocessors = new(require('./preprocessors'))(),
 	slickParse = require('slick').parse,
 	VERSION = require('./../package').version;
@@ -65,6 +66,10 @@ function analyzer(css, options, callback) {
 }
 
 analyzer.version = VERSION;
+
+// @see https://github.com/macbre/phantomas/issues/664
+analyzer.path = path.normalize(__dirname + '/..');
+analyzer.pathBin = analyzer.path + '/bin/analyze-css.js';
 
 // exit codes
 analyzer.EXIT_NEED_OPTIONS = 2;


### PR DESCRIPTION
```js
macbre@debian:~/github/analyze-css$ node
> require('.')
{ [Function: analyzer]
  version: '0.12.2',
  path: '/home/macbre/github/analyze-css',
  pathBin: '/home/macbre/github/analyze-css/bin/analyze-css.js',
  EXIT_NEED_OPTIONS: 2,
  EXIT_PARSING_FAILED: 251,
  EXIT_EMPTY_CSS: 252,
  EXIT_CSS_PASSED_IS_NOT_STRING: 253,
  EXIT_URL_LOADING_FAILED: 254,
  EXIT_FILE_LOADING_FAILED: 255 }
```

See https://github.com/macbre/phantomas/issues/664