### PR TITLE
runner: use process.release.name for user agent

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -22,7 +22,7 @@ function getUserAgent() {
 	return format(
 		'analyze-css/%s (%s %s, %s %s)',
 		version,
-		process.title,
+		process.release.name,
 		process.version,
 		process.platform,
 		process.arch


### PR DESCRIPTION
Using process.title causes "The header content contains invalid characters" in some cases.

Fixes #136