### PR TITLE
Run TravisCI tests using Node.js 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 7
   - 6
   - 5
   - 4


### PR DESCRIPTION
Node.js 7.2.x is the latest from `current` branch