### PR TITLE
Drop support for Node v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 6
   - 5
   - 4
-  - 0.12
 sudo: false
 script: "npm test && npm run-script lint"
 cache:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">=0.8"
+    "node": ">=4.0"
   },
   "dependencies": {
     "cli": "^1.0.0",


### PR DESCRIPTION
According to https://github.com/nodejs/LTS#lts-schedule v0.12 release support will end 2016-12-31