### PR TITLE
CI | use the latest node-sass version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run tests (with node-sass support)
       run: |
-        npm install node-sass@4.14.1
+        time npm install node-sass@4.14.1
         npm test
 
     - name: Run bin/analyze-css.js for CSS file

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run tests (with node-sass support)
       run: |
-        time npm install node-sass@4.14.1
+        time npm install node-sass@5.0.0
         npm test
 
     - name: Run bin/analyze-css.js for CSS file


### PR DESCRIPTION
`npm install node-sass@4.14.1` takes a long time on Node 15.x

## Node.js 14.x

```
real	0m6.433s
```

## Node.js 15.x

```
real	2m28.373s
```