### PR TITLE
Fix handling of URLs with semicolons

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,6 +172,15 @@ analyzer.prototype = {
     }, this);
   },
 
+  fixCss: function (css) {
+    // properly handle ; in @import URLs
+    // see https://github.com/macbre/analyze-css/pull/322
+    // see https://github.com/reworkcss/css/issues/137
+    return css.replace(/@import url([^)]+["'])/, (match) => {
+      return match.replace(/;/g, "%3B");
+    });
+  },
+
   parseCss: function (css) {
     var debug = require("debug")("analyze-css:parser");
     debug("Going to parse %s kB of CSS", (css.length / 1024).toFixed(2));
@@ -179,6 +188,8 @@ analyzer.prototype = {
     if (css.trim() === "") {
       return this.error("Empty CSS was provided", analyzer.EXIT_EMPTY_CSS);
     }
+
+    css = this.fixCss(css);
 
     this.tree = cssParser(css, {
       // errors are listed in the parsingErrors property instead of being thrown (#84)
@@ -303,7 +314,9 @@ analyzer.prototype = {
 
         // {"type":"import","import":"url('/css/styles.css')"}
         case "import":
-          this.emit("import", rule.import);
+          // replace encoded semicolon back into ;
+          // https://github.com/macbre/analyze-css/pull/322
+          this.emit("import", rule.import.replace(/%3B/g, ";"));
           break;
       }
     }, this);

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,8 @@ analyzer.prototype = {
   },
 
   parseRules: function (rules) {
+    const debug = require("debug")("analyze-css:parseRules");
+
     rules.forEach(function (rule) {
       debug("%j", rule);
 

--- a/test/fixes/280-url-with-semicolons.test.js
+++ b/test/fixes/280-url-with-semicolons.test.js
@@ -12,7 +12,7 @@ body {
 }
             `.trim();
 
-        new analyzer(css, (err, res) => {
+        new analyzer(css, (err) => {
             assert.ok(err === null, err);
         });
 	});

--- a/test/fixes/280-url-with-semicolons.test.js
+++ b/test/fixes/280-url-with-semicolons.test.js
@@ -5,15 +5,17 @@ describe('@import rule with url containing semicolon', () => {
 	it('is properly parsed', () => {
         const analyzer = require('../..'),
             css = `
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;800&display=swap');
 
 body {
 
 }
             `.trim();
 
-        new analyzer(css, (err) => {
+        new analyzer(css, (err, res) => {
             assert.ok(err === null, err);
+            assert.strictEqual(res.metrics.imports, 1, '@import is detected');
+            assert.deepStrictEqual(res.offenders.imports[0].message, "url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;800&display=swap')");
         });
 	});
 });

--- a/test/fixes/280-url-with-semicolons.test.js
+++ b/test/fixes/280-url-with-semicolons.test.js
@@ -1,0 +1,19 @@
+const { describe, it } = require("@jest/globals");
+const assert = require('assert');
+
+describe('@import rule with url containing semicolon', () => {
+	it('is properly parsed', () => {
+        const analyzer = require('../..'),
+            css = `
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap');
+
+body {
+
+}
+            `.trim();
+
+        new analyzer(css, (err, res) => {
+            assert.ok(err === null, err);
+        });
+	});
+});

--- a/test/fixes/280-url-with-semicolons.test.js
+++ b/test/fixes/280-url-with-semicolons.test.js
@@ -15,6 +15,7 @@ body {
         new analyzer(css, (err, res) => {
             assert.ok(err === null, err);
             assert.strictEqual(res.metrics.imports, 1, '@import is detected');
+            assert.strictEqual(res.metrics.selectors, 1, 'body {} is detected');
             assert.deepStrictEqual(res.offenders.imports[0].message, "url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;800&display=swap')");
         });
 	});


### PR DESCRIPTION
Resolves #280 // see https://github.com/reworkcss/css/issues/137

----

```
$ echo "@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap'); body {}" | DEBUG=* ./bin/analyze-css.js -
  analyze-css:bin analyze-css v0.13.0 +0ms
...
  analyze-css:parser Going to parse 0.10 kB of CSS +0ms
  analyze-css:parser CSS parsed +1ms
  analyze-css {"type":"import","import":"url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400","position":{"start":{"line":1,"column":1},"end":{"line":1,"column":75}}} +17ms
  analyze-css {"type":"rule","selectors":["600&display=swap'); body"],"declarations":[],"position":{"start":{"line":1,"column":75},"end":{"line":1,"column":102}}} +0ms
  analyze-css:bin Exiting with exit code #1 +21ms
Error: 600&display=swap'); body is an invalid expression
```