### PR TITLE
Fixing the base64 regex slow lookup issue

### DIFF
--- a/rules/base64.js
+++ b/rules/base64.js
@@ -7,8 +7,7 @@ var format = require("util").format,
  * @param { import("../lib/css-analyzer") } analyzer
  */
 function rule(analyzer) {
-  // @see http://stackoverflow.com/a/11335500
-  var re = /data:.+\/(.+);base64,(.*)\)/;
+  var re = /data:[^/]+\/([^;]+)(?:;charset=[^;]+)?;base64,([a-zA-Z0-9][^)]+)/;
   analyzer.setMetric("base64Length");
 
   analyzer.on("declaration", function (rule, property, value) {


### PR DESCRIPTION
# Problem
In some odd cases I have realized the regex for `base64 `can be very slow.

In my opinion the issue can arrise when the data-url is used for something else than `base64`.
An example would be an inline svg:
```
background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' .....
```

The first part of the regex `.+\/(.+);` will try to read in all the way to the end of the css file if no other `base64` inline url is declared. On big files this ends up slowing down `analyze-css` greatly.

# Proposed solution
The proposed solution would be to tighten down the regex constraints to only match `[^\/]+\/([^;]+)(?:;charset=[^;]+)?` before the base64 part and  `([a-zA-Z0-9][^)]+)` in order to loosely match the following format: `data:[<mime type>][;charset=<charset>][;base64],<encoded data>`

---

See #598 for an initial PR from @gregoirelinot