### PR TITLE
Fixing the base64 rule

### DIFF
--- a/rules/base64.js
+++ b/rules/base64.js
@@ -7,7 +7,7 @@ var format = require("util").format,
  * @param { import("../lib/css-analyzer") } analyzer
  */
 function rule(analyzer) {
-  var re = /data:[^/]+\/([^;]+)(?:;charset=[^;]+)?;base64,([a-zA-Z0-9][^)]+)/;
+  var re = /data:[^/]+\/([^;]+)(?:;charset=[^;]+)?;base64,([^)]+)/;
   analyzer.setMetric("base64Length");
 
   analyzer.on("declaration", function (rule, property, value) {


### PR DESCRIPTION
Fixing the regex as `base64 `can start with something else than [a-zA-Z-0-9], a false assumption which I took when creating the regex initially. 
An example of this is the first bytes of a jpeg images: `FF D8 FF` which is  `/9j/` in base64
