### PR TITLE
fix(complex): ignore traversals selector types

### DIFF
--- a/rules/complex.js
+++ b/rules/complex.js
@@ -10,8 +10,15 @@ function rule(analyzer) {
 
   // #foo .bar ul li a
   analyzer.on("selector", function (rule, selector, expressions) {
-    var filteredExpr = expressions.filter((item) => {
-      return ! ["adjacent", "parent", "child", "descendant", "sibling", "column-combinator"].includes(item.type);
+    let filteredExpr = expressions.filter((item) => {
+      return ![
+        "adjacent",
+        "parent",
+        "child",
+        "descendant",
+        "sibling",
+        "column-combinator",
+      ].includes(item.type);
     });
     if (filteredExpr.length > COMPLEX_SELECTOR_THRESHOLD) {
       analyzer.incrMetric("complexSelectors");

--- a/rules/complex.js
+++ b/rules/complex.js
@@ -10,7 +10,10 @@ function rule(analyzer) {
 
   // #foo .bar ul li a
   analyzer.on("selector", function (rule, selector, expressions) {
-    if (expressions.length > COMPLEX_SELECTOR_THRESHOLD) {
+    var filteredExpr = expressions.filter((item) => {
+      return ! ["adjacent", "parent", "child", "descendant", "sibling", "column-combinator"].includes(item.type);
+    });
+    if (filteredExpr.length > COMPLEX_SELECTOR_THRESHOLD) {
       analyzer.incrMetric("complexSelectors");
       analyzer.addOffender("complexSelectors", selector);
     }


### PR DESCRIPTION
complex selectors should ignore [traversals selector types](https://github.com/fb55/css-what/blob/master/src/types.ts#L16) 

So `#foo .bar ul li a` complixity level would be `5` rather than `9`
