### PR TITLE
Fix runner.js HTTP error handling to properly propagate fetch errors

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -48,13 +48,9 @@ async function request(requestOptions, callback) {
       debug("Headers: %j", resp.headers._headers);
 
       if (!resp.ok) {
-        var err = new Error(
-          "HTTP request failed: " +
-            (err
-              ? err.toString()
-              : "received HTTP " + resp.status + " " + resp.statusText),
-        );
-        callback(err);
+        callback(new Error(
+          "HTTP request failed: received HTTP " + resp.status + " " + resp.statusText
+        ));
       } else {
         return resp.text(); // a promise
       }


### PR DESCRIPTION
The request function in runner.js had a bug in the .then handler that referenced an undefined variable 'err' when checking resp.ok. This caused fetch errors (non-2xx status) to throw an unhandled promise rejection instead of properly calling the callback with an error. Fixed by using the resp.statusText directly and ensuring the error object is correctly constructed.